### PR TITLE
Support multiple browsers viewing video at once

### DIFF
--- a/web/appCam.py
+++ b/web/appCam.py
@@ -1,6 +1,9 @@
 from flask import Flask, render_template, Response
 import cv2
 import time
+import zmq
+import numpy as np
+import base64
 
 app = Flask(__name__)
 
@@ -10,24 +13,30 @@ def index():
 
 class VideoCamera(object):
     def __init__(self):
-        self.video = cv2.VideoCapture(0)
-    def __del__(self):
-        self.video.release()
+        self.context = zmq.Context()
+        self.socket = self.context.socket(zmq.SUB)
+        self.socket.setsockopt_string(zmq.SUBSCRIBE, np.unicode(''))
+        self.socket.setsockopt(zmq.CONFLATE, 1)
+        self.socket.connect("tcp://localhost:5555")
     def get_frame(self):
-        success, image = self.video.read()
+        jpg_frame = self.socket.recv_string()
+        jpg_image = base64.b64decode(jpg_frame)
+        #image = self.socket.recv_pyobj()
+        #success, image = self.video.read()
         #for i in range(0, 4):
         #    self.video.grab()
-        print('success', success)
-        ret, jpeg = cv2.imencode('.jpg', image)
-        print('ret', ret)
-        return jpeg.tobytes()
+        #print('success', success)
+        #ret, jpeg = cv2.imencode('.jpg', image)
+        #return jpg_image.tobytes()
+        return jpg_image
 
 def gen(camera):
     while True:
         frame = camera.get_frame()
         if frame == None:
-            print('here')
-        yield (b'--frame\r\n'
+            print('noneFrame occurred')
+        else:
+            yield (b'--frame\r\n'
                b'Content-Type: image/jpeg\r\n\r\n' + frame + b'\r\n\r\n')
 
 @app.route('/video_feed')
@@ -36,4 +45,4 @@ def video_feed():
                     mimetype='multipart/x-mixed-replace; boundary=frame')
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', debug=True)
+    app.run(host='0.0.0.0', threaded=True, debug=True)

--- a/web/zmqPub.py
+++ b/web/zmqPub.py
@@ -1,6 +1,7 @@
 from time import sleep
 import zmq
 import cv2
+import base64
 
 context = zmq.Context()
 socket = context.socket(zmq.PUB)
@@ -13,8 +14,8 @@ captured_count = 0
 while True:
     captured_count += 1
     ret, frame = capture.read()
-    socket.send_string(topic, zmq.SNDMORE)
-    socket.send_pyobj(frame)
+    _, buffer = cv2.imencode('.jpg', frame)
+    socket.send(base64.b64encode(buffer))
     if captured_count % 10 == 0:
         print(f'Have send {captured_count} frames')
 

--- a/web/zmqRec.py
+++ b/web/zmqRec.py
@@ -1,18 +1,22 @@
 from time import sleep
 import zmq
+import base64
+import numpy as np
 
 context = zmq.Context()
 socket = context.socket(zmq.SUB)
+socket.setsockopt(zmq.CONFLATE, 1)
+socket.setsockopt_string(zmq.SUBSCRIBE, np.unicode(''))
 socket.connect("tcp://localhost:5555")
-socket.setsockopt(zmq.SUBSCRIBE, b'camera_frame')
+#socket.setsockopt(zmq.SUBSCRIBE, b'camera_frame')
 sleep(2)
-
+print('was here1')
 received_count = 0
 while True:
     received_count += 1
     # just receive the topic string and toss away
-    socket.recv_string()
-    frame = socket.recv_pyobj()
+    frame = socket.recv_string()
+    jpg_img = base64.b64decode(frame)
     if received_count % 10 == 0:
         print(f'total received frames: {received_count}')
 


### PR DESCRIPTION
Change up how we're sending the video so that we're not doing a topic followed by content every time. Instead every message is the newest frame, converted to jpeg and 64 bit encoded to string. Then change zmq to use CONFLATE, so that each receiver is only going for the newest frames rather than all of them. This increases lag for the first viewer a smidge, but makes it so multiple viewers all get the same experience.