### PR TITLE
Add installs needed for faster image streaming to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@ sudo apt-get install apache2 -y
 sudo apt-get install python3-flask 
 sudo apt-get install libqt4-test libqtgui4
 sudo apt-get install libatlas-base-dev libjasper-dev
+sudo apt-get install cmake git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev
+sudo apt-get install python-dev python-numpy libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libjasper-dev libdc1394-22-dev
 
 use Safari browser
 
+Need to start zmq publisher first, run `python zmqPub.py` in web first.
 in ./web use `python3 appCam.py` currently port is 5000


### PR DESCRIPTION
Adding these libraries let's opencv use ffmpeg internally which really helps. I reduced the lag when there are 3 web consumers at once from ~5 seconds to ~1 second. Almost not lag was present with 2 consumers now, down from at least 2 seconds.